### PR TITLE
Fix deprecated call to is_taxonomy

### DIFF
--- a/xili-tidy-tags/xili-tidy-tags.php
+++ b/xili-tidy-tags/xili-tidy-tags.php
@@ -477,7 +477,7 @@ function xili_get_object_terms($object_ids, $taxonomies, $args = array()) {
 		$taxonomies = array($taxonomies);
 
 	foreach ( (array) $taxonomies as $taxonomy ) {
-		if ( ! is_taxonomy($taxonomy) )
+		if ( ! taxonomy_exists($taxonomy) )
 			return new WP_Error('invalid_taxonomy', __('Invalid Taxonomy'));
 	}
 


### PR DESCRIPTION
https://developer.wordpress.org/reference/functions/is_taxonomy/

This will throw warnings if not fixed.
